### PR TITLE
Always return a number from this function

### DIFF
--- a/components/Conversation.tsx
+++ b/components/Conversation.tsx
@@ -21,6 +21,8 @@ const Conversation = ({ localParticipant, participants }) => {
     if (query?.gain) {
       // default to muting
       return parseInt(query.gain as string, 10) || 0;
+    } else {
+      return 0;
     }
   };
 


### PR DESCRIPTION
Otherwise the app crashes when we try to use `undefined` here later on:

https://github.com/eatspaint/virtual-bar-client/blob/f8b595cf351127811779387662333b90fd39e5e3/components/Participant.tsx#L50